### PR TITLE
chore(deps): bump Turbo 8 + Stimulus 3.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Personal blog at https://callmarx.dev — Jekyll + Tailwind + Hotwire, deployed 
 
 - **Static generator:** Jekyll 4.3.x (`src/` source → `src/_site/` output)
 - **Styling:** Tailwind CSS 3.1.4 (PostCSS pipeline, dark mode via `class` strategy)
-- **JS:** Hotwire (Turbo 7.1, Stimulus 3.1) bundled by Webpack 5
+- **JS:** Hotwire (Turbo 8.x, Stimulus 3.2.x) bundled by Webpack 5 — page morphing + View Transitions enabled via `<meta>` tags in `_layouts/default.html`
 - **Plugins:** `jekyll-paginate-v2`, `jekyll-seo-tag`, `jekyll-sitemap`
 - **Ruby:** 3.4.9 (`.ruby-version`, `mise.toml`) — managed via Bundler
 - **Node:** 22 LTS / NPM 10 (per `netlify.toml`, `mise.toml`)
@@ -158,8 +158,6 @@ Most pins are behind. Order them by impact / risk:
 | Component | Current | Latest | Notes |
 |---|---|---|---|
 | Tailwind | 3.1.4 | 4.2 | **breaking**. New Oxide engine, CSS-first `@theme` config, `bg-gradient-to-*` → `bg-linear-to-*`, drops legacy aliases. Run `npx @tailwindcss/upgrade`. Browser support tightens (Safari 16.4+, Chrome 111+, FF 128+). Migrate webpack pipeline to `@tailwindcss/webpack` (drops `postcss-loader`, `postcss-import`, `autoprefixer`). |
-| @hotwired/turbo | 7.1.0 | 8.0.23 | major — review Turbo 8 changelog, especially morphing + view transitions. |
-| @hotwired/stimulus | 3.1.0 | 3.2.2 | minor. |
 | Babel + loaders | 7.18.x | 7.2x | minor. Bundle alongside Tailwind v4 PR (build pipeline rewrite). |
 | Twitter link | active | dead-ish | `twitter.com/callmarx_dev` → consider X domain or remove. |
 | `deploy` branch | stale | — | delete locally + on origin. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,9 @@
       "dependencies": {
         "@babel/core": "^7.18.9",
         "@babel/preset-env": "^7.18.9",
-        "@hotwired/stimulus": "^3.1.0",
+        "@hotwired/stimulus": "^3.2.2",
         "@hotwired/stimulus-webpack-helpers": "^1.0.1",
-        "@hotwired/turbo": "^7.1.0",
+        "@hotwired/turbo": "^8.0.23",
         "@tailwindcss/typography": "^0.5.2",
         "autoprefixer": "^10.4.7",
         "babel-loader": "^8.2.5",
@@ -1641,11 +1641,12 @@
       }
     },
     "node_modules/@hotwired/turbo": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.3.0.tgz",
-      "integrity": "sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==",
+      "version": "8.0.23",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-8.0.23.tgz",
+      "integrity": "sha512-GZ7cijxEZ6Ig71u7rD6LHaRv/wcE/hNsc+nEfiWOkLNqUgLOwo5MNGWOy5ZV9ZUDSiQx1no7YxjTNnT4O6//cQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "dependencies": {
     "@babel/core": "^7.18.9",
     "@babel/preset-env": "^7.18.9",
-    "@hotwired/stimulus": "^3.1.0",
+    "@hotwired/stimulus": "^3.2.2",
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
-    "@hotwired/turbo": "^7.1.0",
+    "@hotwired/turbo": "^8.0.23",
     "@tailwindcss/typography": "^0.5.2",
     "autoprefixer": "^10.4.7",
     "babel-loader": "^8.2.5",

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -11,6 +11,9 @@
     {% seo %}
     {% include analytics.html %}
     {% include head-darkmode-check.html %}
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="preserve">
+    <meta name="view-transition" content="same-origin">
     <script type="text/javascript" src="{{ '/assets/main-bundle.js' }}"></script>
   </head>
   <body class="bg-beige-100 dark:bg-slate-900">


### PR DESCRIPTION
## Summary
- Bumps `@hotwired/turbo` `^7.1.0` → `^8.0.23` and `@hotwired/stimulus` `^3.1.0` → `^3.2.2`.
- Adds three `<meta>` tags to `src/_layouts/default.html` to opt into Turbo 8 features:
  - `turbo-refresh-method=morph` — idiomorph diff on same-page reloads (preserves scroll/focus/form state).
  - `turbo-refresh-scroll=preserve` — keep scroll on morph reload.
  - `view-transition=same-origin` — native cross-fade between same-origin navigations (Chromium; no-op on Firefox/Safari < 18).
- Updates `CLAUDE.md` stack snapshot and strikes the Hotwire rows from the upgrade backlog.

PR 1 of the upgrade sweep already merged (#28). PR 3 (Tailwind v4) lands next, off `develop` after this merges.

## Test plan
- [ ] `mise exec -- bin/build` clean
- [ ] `mise exec -- bin/dev` — `http://localhost:4000`
  - [ ] Pagination arrow on home → only post list updates (Turbo Frame swap, no full reload)
  - [ ] Click a tag link → full nav (`data-turbo="false"` opt-out preserved)
  - [ ] Toggle dark mode → `.dark` toggles + persists across navigation
  - [ ] Home → article → back. Look for view transition fade on Chromium; graceful no-op on Firefox.
  - [ ] Scroll down on home → click article → back → scroll position restored
- [ ] Netlify deploy preview builds green
- [ ] Network tab — no stale-bundle issues

## Risk callouts
- View Transitions are best-effort: Firefox + Safari < 18 ignore the meta tag silently. No regression.
- Morph re-runs Stimulus `connect()`; current `dark_mode_controller` only reads `classList` → safe. Future controllers must handle morph re-`connect()`.
- Turbo 8 minor breaking: `Turbo.cache.clear()` removed (replaced by `Turbo.session.clearCache()`). Not used in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)