### PR TITLE
feat(ui): terminal identity pass + mobile polish

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -26,26 +26,40 @@
   {%- comment -%} Desktop icons (md+) {%- endcomment -%}
   <div class="hidden md:flex items-center text-stone-900 dark:text-tokyo-fg shrink-0" data-controller="dark-mode">
     <a class="flex items-center p-1 -m-1 transition duration-200 ease-in-out {% if tags_active %}text-tokyo-pink{% else %}hover:opacity-40{% endif %}" href="{{ root_path }}tags/" data-tip="Tags"{% if tags_active %} aria-current="page"{% endif %}>
-      <svg class="w-8 h-8" fill="currentColor" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-        <path d="M2 2a1 1 0 0 1 1-1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 2 6.586V2zm3.5 4a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/>
-        <path d="M1.293 7.793A1 1 0 0 1 1 7.086V2a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l.043-.043-7.457-7.457z"/>
+      <svg class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <line x1="4" y1="9" x2="20" y2="9"/>
+        <line x1="4" y1="15" x2="20" y2="15"/>
+        <line x1="10" y1="3" x2="8" y2="21"/>
+        <line x1="16" y1="3" x2="14" y2="21"/>
       </svg>
-      <strong class="ml-1 {% if tags_active %}font-semibold{% endif %}">Tags</strong>
+      <strong class="ml-1.5 {% if tags_active %}font-semibold{% endif %}">Tags</strong>
     </a>
     <a class="flex items-center ml-4 p-1 -m-1 transition duration-200 ease-in-out {% if about_active %}text-tokyo-pink{% else %}hover:opacity-40{% endif %}" href="{{ root_path }}about/" data-tip="{{ site.data.translations.about[page.locale] }}"{% if about_active %} aria-current="page"{% endif %}>
-      <svg class="w-8 h-8" fill="currentColor" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg">
-        <path d="M13 20h-7c-2.174-3.004-4-6.284-4-12h15c0 5.667-1.88 9.089-4 12zm5.119-10c-.057.701-.141 1.367-.252 2h1.55c-.449 1.29-1.5 2.478-2.299 2.914-.358 1.038-.787 1.981-1.26 2.852 3.274-1.143 5.846-4.509 6.142-7.766h-3.881zm-7.745-3.001c4.737-4.27-.98-4.044.117-6.999-3.783 3.817 1.409 3.902-.117 6.999zm-2.78.001c3.154-2.825-.664-3.102.087-5.099-2.642 2.787.95 2.859-.087 5.099zm9.406 15h-15v2h15v-2z"/>
+      <svg class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M17 8h1a4 4 0 0 1 0 8h-1"/>
+        <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z"/>
+        <line x1="7" y1="2" x2="7" y2="5"/>
+        <line x1="11" y1="2" x2="11" y2="5"/>
+        <line x1="15" y1="2" x2="15" y2="5"/>
       </svg>
-      <strong class="ml-1 {% if about_active %}font-semibold{% endif %}">{{ site.data.translations.about[page.locale] }}</strong>
+      <strong class="ml-1.5 {% if about_active %}font-semibold{% endif %}">{{ site.data.translations.about[page.locale] }}</strong>
     </a>
     <button data-action="click->dark-mode#toggle" aria-label="Toggle dark mode" data-tip="{{ site.data.translations.theme[page.locale] }}" class="flex items-center ml-3 p-1 -m-1 hover:opacity-40 transition duration-200 ease-in-out">
-      <svg data-dark-mode-target="darkIcon" class="w-8 h-8 hidden" fill="currentColor" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">
-        <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
+      <svg data-dark-mode-target="darkIcon" class="w-7 h-7 hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
       </svg>
-      <svg data-dark-mode-target="lightIcon" class="w-8 h-8 hidden" fill="currentColor" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">
-        <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path>
+      <svg data-dark-mode-target="lightIcon" class="w-7 h-7 hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <circle cx="12" cy="12" r="4"/>
+        <line x1="12" y1="2" x2="12" y2="4"/>
+        <line x1="12" y1="20" x2="12" y2="22"/>
+        <line x1="4.93" y1="4.93" x2="6.34" y2="6.34"/>
+        <line x1="17.66" y1="17.66" x2="19.07" y2="19.07"/>
+        <line x1="2" y1="12" x2="4" y2="12"/>
+        <line x1="20" y1="12" x2="22" y2="12"/>
+        <line x1="4.93" y1="19.07" x2="6.34" y2="17.66"/>
+        <line x1="17.66" y1="6.34" x2="19.07" y2="4.93"/>
       </svg>
-      <strong class="ml-1">{{ site.data.translations.theme[page.locale] }}</strong>
+      <strong class="ml-1.5">{{ site.data.translations.theme[page.locale] }}</strong>
     </button>
   </div>
 </header>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -5,33 +5,47 @@
   {% assign root_path = '/' %}
   {% assign translated_locale = 'pt_BR' %}
 {% endif %}
-<header id="site-header" class="flex justify-between pt-6 pb-3 border-b border-stone-400 dark:border-tokyo-border">
-  <div class="flex justify-between text-stone-900 dark:text-tokyo-fg">
+<header id="site-header" class="flex items-center justify-between gap-2 pt-6 pb-3 border-b border-stone-400 dark:border-tokyo-border">
+  <div class="flex items-center text-stone-900 dark:text-tokyo-fg shrink-0">
     {% include translate-icon.html translated_locale=translated_locale %}
   </div>
-  <a class="font-marker text-2xl xs:text-3xl md:text-4xl text-stone-900 dark:text-tokyo-fg hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200 ease-in-out" href="{{ root_path }}">{{ site.title }}</a>
-  <div class="flex justify-between text-stone-900 dark:text-tokyo-fg" data-controller="dark-mode">
-    <a class="flex hover:opacity-40 transition duration-200 ease-in-out" href="{{ root_path }}tags/" aria-label="Tags icon">
-      <svg class="w-6 h-6 mt-1" fill="currentColor" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <a class="font-marker text-xl xs:text-2xl sm:text-3xl md:text-4xl text-stone-900 dark:text-tokyo-fg hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200 ease-in-out truncate min-w-0 text-center" href="{{ root_path }}">
+    <span class="xs:hidden">~/eugenio</span>
+    <span class="hidden xs:inline">{{ site.title }}</span>
+  </a>
+  {% assign tags_active = false %}{% if page.url contains '/tags' %}{% assign tags_active = true %}{% endif %}
+  {% assign about_active = false %}{% if page.url contains '/about' %}{% assign about_active = true %}{% endif %}
+
+  {%- comment -%} Mobile text buttons (below md) {%- endcomment -%}
+  <div class="flex md:hidden items-center justify-end gap-0.5 sm:gap-2 font-mono text-xs sm:text-sm text-stone-700 dark:text-tokyo-fg shrink-0" data-controller="dark-mode">
+    <a class="px-1 sm:px-2 py-1 transition duration-200 {% if tags_active %}text-tokyo-pink font-semibold{% else %}hover:text-tokyo-blue dark:hover:text-tokyo-blue{% endif %}" href="{{ root_path }}tags/"{% if tags_active %} aria-current="page"{% endif %}>[<span class="hidden sm:inline"> </span>tags<span class="hidden sm:inline"> </span>]</a>
+    <a class="px-1 sm:px-2 py-1 transition duration-200 {% if about_active %}text-tokyo-pink font-semibold{% else %}hover:text-tokyo-blue dark:hover:text-tokyo-blue{% endif %}" href="{{ root_path }}about/"{% if about_active %} aria-current="page"{% endif %}>[<span class="hidden sm:inline"> </span>{{ site.data.translations.about[page.locale] | downcase }}<span class="hidden sm:inline"> </span>]</a>
+    <button data-action="click->dark-mode#toggle" aria-label="Toggle dark mode" class="px-1 sm:px-2 py-1 hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200">[<span class="hidden sm:inline"> </span>{{ site.data.translations.theme[page.locale] | downcase }}<span class="hidden sm:inline"> </span>]</button>
+  </div>
+
+  {%- comment -%} Desktop icons (md+) {%- endcomment -%}
+  <div class="hidden md:flex items-center text-stone-900 dark:text-tokyo-fg shrink-0" data-controller="dark-mode">
+    <a class="flex items-center p-1 -m-1 transition duration-200 ease-in-out {% if tags_active %}text-tokyo-pink{% else %}hover:opacity-40{% endif %}" href="{{ root_path }}tags/" data-tip="Tags"{% if tags_active %} aria-current="page"{% endif %}>
+      <svg class="w-8 h-8" fill="currentColor" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
         <path d="M2 2a1 1 0 0 1 1-1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 2 6.586V2zm3.5 4a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/>
         <path d="M1.293 7.793A1 1 0 0 1 1 7.086V2a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l.043-.043-7.457-7.457z"/>
       </svg>
-      <strong class="hidden mt-1 ml-1 md:block">Tags</strong>
+      <strong class="ml-1 {% if tags_active %}font-semibold{% endif %}">Tags</strong>
     </a>
-    <a class="flex ml-2 sm:ml-4 hover:opacity-40 transition duration-200 ease-in-out" href="{{ root_path }}about/" aria-label="coffee cup icon">
+    <a class="flex items-center ml-4 p-1 -m-1 transition duration-200 ease-in-out {% if about_active %}text-tokyo-pink{% else %}hover:opacity-40{% endif %}" href="{{ root_path }}about/" data-tip="{{ site.data.translations.about[page.locale] }}"{% if about_active %} aria-current="page"{% endif %}>
       <svg class="w-8 h-8" fill="currentColor" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg">
         <path d="M13 20h-7c-2.174-3.004-4-6.284-4-12h15c0 5.667-1.88 9.089-4 12zm5.119-10c-.057.701-.141 1.367-.252 2h1.55c-.449 1.29-1.5 2.478-2.299 2.914-.358 1.038-.787 1.981-1.26 2.852 3.274-1.143 5.846-4.509 6.142-7.766h-3.881zm-7.745-3.001c4.737-4.27-.98-4.044.117-6.999-3.783 3.817 1.409 3.902-.117 6.999zm-2.78.001c3.154-2.825-.664-3.102.087-5.099-2.642 2.787.95 2.859-.087 5.099zm9.406 15h-15v2h15v-2z"/>
       </svg>
-      <strong class="hidden mt-1 md:block">{{ site.data.translations.about[page.locale] }}</strong>
+      <strong class="ml-1 {% if about_active %}font-semibold{% endif %}">{{ site.data.translations.about[page.locale] }}</strong>
     </a>
-    <button data-action="click->dark-mode#toggle" class="flex ml-1 sm:ml-3 hover:opacity-40 transition duration-200 ease-in-out">
-      <svg data-dark-mode-target="darkIcon" class="w-8 h-8 mt-1 hidden" fill="currentColor" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">
+    <button data-action="click->dark-mode#toggle" aria-label="Toggle dark mode" data-tip="{{ site.data.translations.theme[page.locale] }}" class="flex items-center ml-3 p-1 -m-1 hover:opacity-40 transition duration-200 ease-in-out">
+      <svg data-dark-mode-target="darkIcon" class="w-8 h-8 hidden" fill="currentColor" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">
         <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
       </svg>
-      <svg data-dark-mode-target="lightIcon" class="w-8 h-8 mt-1 hidden" fill="currentColor" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">
+      <svg data-dark-mode-target="lightIcon" class="w-8 h-8 hidden" fill="currentColor" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">
         <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path>
       </svg>
-      <strong class="hidden -ml-1 mt-1 md:block">{{ site.data.translations.theme[page.locale] }}</strong>
+      <strong class="ml-1">{{ site.data.translations.theme[page.locale] }}</strong>
     </button>
   </div>
 </header>

--- a/src/_includes/listed-post.html
+++ b/src/_includes/listed-post.html
@@ -8,58 +8,73 @@
   {% else %}
     {% assign prompt_cmd = "--all" %}
   {% endif %}
+
   <div class="font-mono text-sm md:text-base text-stone-600 dark:text-tokyo-fg-dim mb-4 lg:w-11/12 self-center w-full">
-    <span class="text-tokyo-green">eugenio@dev</span><span class="text-stone-500 dark:text-tokyo-fg-dim">:</span><span class="text-tokyo-blue">~</span><span class="text-stone-500 dark:text-tokyo-fg-dim">$</span> postlist {{ prompt_cmd }}
+    <span class="text-tokyo-green">eugenio@dev</span><span class="text-stone-500 dark:text-tokyo-fg-dim">:</span><span class="text-tokyo-blue">~</span><span class="text-stone-500 dark:text-tokyo-fg-dim">$</span> postlist {{ prompt_cmd }}<span class="cursor-blink"></span>
   </div>
+
   <div class="self-center w-full lg:w-11/12 flex flex-row-reverse sm:flex-row items-center mb-2">
     <div class="hidden sm:block grow border-t border-stone-300 dark:border-tokyo-border"></div>
     {% if paginator.total_pages > 1 %}
-      <div class="inline-flex items-center gap-2 font-mono text-sm md:text-base">
+      <div class="flex flex-wrap items-center justify-end gap-x-1 sm:gap-x-2 gap-y-1 font-mono text-xs sm:text-sm md:text-base">
         {% unless paginator.previous_page %}
-          <span class="px-2 py-1 text-stone-400 dark:text-tokyo-border select-none" aria-hidden="true">[ prev ]</span>
+          <span class="px-1.5 sm:px-2 py-1 text-stone-400 dark:text-tokyo-border select-none" aria-hidden="true">[ prev ]</span>
         {% else %}
-          <a class="px-2 py-1 text-stone-700 dark:text-tokyo-fg hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200" href="{{ paginator.previous_page_path }}" data-turbo-frame="listing-posts" data-turbo-action="advance" aria-label="Previous">[ prev ]</a>
+          <a class="px-1.5 sm:px-2 py-1 text-stone-700 dark:text-tokyo-fg hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200" href="{{ paginator.previous_page_path }}" data-turbo-frame="listing-posts" data-turbo-action="advance" aria-label="Previous">[ prev ]</a>
         {% endunless %}
         {% if paginator.page_trail %}
-          <span class="text-stone-500 dark:text-tokyo-fg-dim">
+          <span class="inline-flex items-center text-stone-500 dark:text-tokyo-fg-dim">
             {% for trail in paginator.page_trail %}
               {% if page.pagination_info.curr_page == trail.num %}
-                <span class="text-tokyo-pink font-semibold">{{ trail.num }}</span>
+                <span class="inline-block px-1.5 sm:px-2 py-1 text-tokyo-pink font-semibold">{{ trail.num }}</span>
               {% else %}
-                <a class="text-stone-600 dark:text-tokyo-fg-dim hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200" href="{{ trail.path }}" data-turbo-frame="listing-posts" data-turbo-action="advance">{{ trail.num }}</a>
+                <a class="inline-block px-1.5 sm:px-2 py-1 text-stone-600 dark:text-tokyo-fg-dim hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200" href="{{ trail.path }}" data-turbo-frame="listing-posts" data-turbo-action="advance">{{ trail.num }}</a>
               {% endif %}
-              {% unless forloop.last %}<span class="text-stone-400 dark:text-tokyo-border mx-1">·</span>{% endunless %}
+              {% unless forloop.last %}<span class="text-stone-400 dark:text-tokyo-border select-none" aria-hidden="true">·</span>{% endunless %}
             {% endfor %}
           </span>
         {% endif %}
         {% unless paginator.next_page %}
-          <span class="px-2 py-1 text-stone-400 dark:text-tokyo-border select-none" aria-hidden="true">[ next ]</span>
+          <span class="px-1.5 sm:px-2 py-1 text-stone-400 dark:text-tokyo-border select-none" aria-hidden="true">[ next ]</span>
         {% else %}
-          <a class="px-2 py-1 text-stone-700 dark:text-tokyo-fg hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200" href="{{ paginator.next_page_path }}" data-turbo-frame="listing-posts" data-turbo-action="advance" aria-label="Next">[ next ]</a>
+          <a class="px-1.5 sm:px-2 py-1 text-stone-700 dark:text-tokyo-fg hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200" href="{{ paginator.next_page_path }}" data-turbo-frame="listing-posts" data-turbo-action="advance" aria-label="Next">[ next ]</a>
         {% endunless %}
       </div>
     {% endif %}
   </div>
-  {% for post in include.posts %}
-    <div class="self-center flex flex-col md:flex-row w-full lg:w-11/12 rounded-lg shadow-lg dark:shadow-tokyo-bg-alt dark:bg-tokyo-bg-alt/30 dark:border dark:border-tokyo-border md:my-4 px-6 hover:shadow-2xl dark:hover:border-tokyo-blue transition duration-200 ease-in-out">
-        <div class="mb-2 md:mr-4 md:mb-0 md:w-4/12 ">
-          <a class="block bg-gray-100 {% if post.image_light_bg %}dark:bg-indigo-50{% else %}dark:bg-tokyo-bg-alt{% endif %} rounded-sm" href="{{ post.url }}" data-turbo-frame="_top">
-            <img class="object-contain mx-auto mt-4 mb-2 md:mb-4 xl:my-auto md:h-80 rounded-sm 2xl:mb-3 hover:opacity-40 transition duration-200 ease-in-out" alt="{{ post.image_alt }}" src="{{ post.main_image | default: post.image }}"/></a>
+
+  <div class="self-center w-full lg:w-11/12 font-mono divide-y divide-stone-200 dark:divide-tokyo-border/60 border-y border-stone-200 dark:border-tokyo-border/60">
+    {% for post in include.posts %}
+      {% assign words = post.content | strip_html | number_of_words %}
+      {% assign read_min = words | divided_by: site.word_count | at_least: 2 %}
+      {% assign slug = post.slug %}
+
+      <a href="{{ post.url }}" data-turbo-frame="_top" class="filelist-row group">
+        <div class="flex items-baseline flex-wrap gap-x-2 sm:gap-x-3 gap-y-0 text-xs sm:text-sm text-stone-500 dark:text-tokyo-fg-dim min-w-0">
+          <span class="marker select-none">&gt;</span>
+          <span class="text-tokyo-purple whitespace-nowrap">{{ post.date | date: "%Y-%m-%d" }}</span>
+          <span class="opacity-50">·</span>
+          <span class="text-tokyo-yellow whitespace-nowrap">{{ read_min }} min</span>
+          <span class="opacity-50 hidden xs:inline">·</span>
+          <span class="text-tokyo-green truncate basis-full xs:basis-auto min-w-0">{{ slug }}.md</span>
         </div>
-      <div class="flex-1">
-        <a href="{{ post.url }}" data-turbo-frame="_top" class="text-2xl text-stone-800 dark:text-tokyo-fg font-bold mb-1 hover:text-tokyo-blue dark:hover:text-tokyo-blue transition duration-200 ease-in-out">
-          <h2 class="">{{ post.title }}</h2>
-        </a>
-       {% include date-readtime.html date=post.date content=post.content align=include.align %}
-        <div class="mb-4 prose prose-custom prose-base prose-a:pointer-events-none md:prose-p:text-lg lg:prose-p:text-xl md:prose-lg lg:prose-2xl dark:prose-invert">{{ post.excerpt }}</div>
+
+        <h2 class="mt-1 ml-3 sm:ml-5 text-base sm:text-xl md:text-2xl font-bold text-stone-800 dark:text-tokyo-fg group-hover:text-tokyo-blue transition-colors">
+          {{ post.title }}
+        </h2>
+
+        <p class="mt-1 ml-3 sm:ml-5 text-sm sm:text-base text-stone-600 dark:text-tokyo-fg-dim line-clamp-2">
+          {{ post.excerpt | strip_html | strip_newlines | truncate: 180 }}
+        </p>
+
         {% if post.tags %}
-          <div class="mb-2">
+          <div class="mt-2 ml-3 sm:ml-5 flex flex-wrap gap-x-2 sm:gap-x-3 gap-y-1">
             {% for tag in post.tags %}
-              <a class="inline-block text-sm lg:text-base font-mono mr-3 text-stone-700 dark:text-tokyo-blue hover:text-tokyo-pink dark:hover:text-tokyo-pink transition duration-200" href="/tags/{{ tag | slugify }}" data-turbo-frame="_top">--{{ tag | downcase | replace: ' ', '-' }}</a>
+              <span class="text-xs sm:text-sm text-stone-500 dark:text-tokyo-blue/80 group-hover:text-tokyo-pink transition-colors">--{{ tag | downcase | replace: ' ', '-' }}</span>
             {% endfor %}
           </div>
         {% endif %}
-      </div>
-    </div>
-  {% endfor %}
+      </a>
+    {% endfor %}
+  </div>
 </turbo-frame>

--- a/src/_includes/social-networks.html
+++ b/src/_includes/social-networks.html
@@ -1,5 +1,5 @@
 {% for network in site.data.social-networks %}
-  <a class="py-2 mr-2 h-8 w-8 text-black dark:text-gray-200 hover:opacity-40 transition duration-200 ease-in-out" href="{{ network.link }}" rel="noopener noreferrer nofollow" target="_blank">
+  <a class="inline-flex items-center justify-center w-11 h-11 mr-1 text-black dark:text-gray-200 hover:opacity-40 transition duration-200 ease-in-out [&>svg]:w-8 [&>svg]:h-8" href="{{ network.link }}" rel="noopener noreferrer nofollow" target="_blank" aria-label="{{ network.name | default: 'Social link' }}" data-tip="{{ network.name | default: 'Social link' }}">
     {{ network.logo }}
   </a>
 {% endfor %}

--- a/src/_includes/translate-icon.html
+++ b/src/_includes/translate-icon.html
@@ -20,20 +20,26 @@
   {% endif %}
 {% endif %}
 
-{% if translated_url %}
-  <a class="flex hover:opacity-40 transition duration-200 ease-in-out" href="{{ translated_url }}" aria-label="Tags icon">
+{% if translated_locale == 'en_US' %}
+  {% assign tip_label = 'Read in English' %}
 {% else %}
-  <span class="flex opacity-40">
+  {% assign tip_label = 'Ler em Português' %}
+{% endif %}
+
+{% if translated_url %}
+  <a class="flex items-center p-1 -m-1 hover:opacity-40 transition duration-200 ease-in-out" href="{{ translated_url }}" aria-label="{{ tip_label }}" data-tip="{{ tip_label }}">
+{% else %}
+  <span class="flex items-center p-1 -m-1 opacity-40" data-tip="{{ tip_label }} (unavailable)">
 {% endif %}
   {% if translated_locale == 'en_US' %}
-    <svg class="w-8 h-8 mt-1" fill="currentColor" viewBox="0 0 122.88 100.06">
+    <svg class="w-8 h-8" fill="currentColor" viewBox="0 0 122.88 100.06">
       <style type="text/css">.st0{fill-rule:evenodd;clip-rule:evenodd;}</style>
       <g>
         <path class="st0" d="M6.38,0h110.11c3.51,0,6.39,2.87,6.39,6.38v87.29c0,3.51-2.87,6.38-6.39,6.38H6.38 c-3.51,0-6.38-2.87-6.38-6.38V6.38C0,2.87,2.87,0,6.38,0L6.38,0z M26.1,31.43h30.77v7.95H37.63v5.92h17.83v7.59H37.63v7.33h19.8 v8.42H26.1V31.43L26.1,31.43z M61.23,31.43h10.73l13.95,20.55V31.43h10.86v37.21H85.91L72.04,48.2v20.43H61.23V31.43L61.23,31.43z"></path>
       </g>
     </svg>
   {% else %}
-    <svg class="w-8 h-8 mt-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 799.999 799.999">
+    <svg class="w-8 h-8" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 799.999 799.999">
       <g>
         <path style="fill:#259245;" d="M24.807,646.16V153.838h39.709c6.563,0,11.903-5.34,11.903-11.903v-1h27.806v1
           c0,6.563,5.34,11.903,11.903,11.903h659.064V646.16H24.807z M400,203.178c-2.097,0-4.165,0.558-5.979,1.612L75.74,389.707

--- a/src/_layouts/about.html
+++ b/src/_layouts/about.html
@@ -19,7 +19,7 @@ layout: default
     {{ content }}
   </div>
 
-  <div class="mt-8 flex flex-wrap items-center gap-3 font-mono text-sm md:text-base">
+  <div class="mt-8 flex flex-nowrap items-center gap-2 sm:gap-3 font-mono text-xs xs:text-sm md:text-base whitespace-nowrap">
     <a href="https://github.com/eugeniojimenes/eugenio-resume/releases/latest/download/resume.pdf"
        target="_blank" rel="noopener"
        class="px-3 py-1 border border-stone-400 dark:border-tokyo-border rounded-sm text-stone-700 dark:text-tokyo-fg hover:border-tokyo-green hover:text-tokyo-green dark:hover:border-tokyo-green dark:hover:text-tokyo-green transition duration-200">
@@ -29,7 +29,7 @@ layout: default
        class="px-3 py-1 border border-stone-400 dark:border-tokyo-border rounded-sm text-stone-700 dark:text-tokyo-fg hover:border-tokyo-yellow hover:text-tokyo-yellow dark:hover:border-tokyo-yellow dark:hover:text-tokyo-yellow transition duration-200">
       [ mailto ]
     </a>
-    <a href="{% if page.locale == 'pt_BR' %}/pt-br/{% else %}/{% endif %}"
+    <a href="{% if page.locale == 'pt_BR' %}/pt-br/#posts{% else %}/#posts{% endif %}"
        class="px-3 py-1 border border-stone-400 dark:border-tokyo-border rounded-sm text-stone-700 dark:text-tokyo-fg hover:border-tokyo-blue hover:text-tokyo-blue dark:hover:border-tokyo-blue dark:hover:text-tokyo-blue transition duration-200">
       [ ~/posts ]
     </a>

--- a/src/_layouts/autopages_tags.html
+++ b/src/_layouts/autopages_tags.html
@@ -30,7 +30,7 @@ layout: default
         <span class="text-tokyo-pink"># </span>{{ page.title }}
         {% if page.selected_tag != 'index' %}
           <a href="{{ root_path }}tags/" data-turbo-action="advance"
-             class="ml-2 text-xs text-tokyo-fg-dim hover:text-tokyo-pink transition duration-200">[ clear filter ]</a>
+             class="inline-block ml-2 px-2 py-1 text-xs text-tokyo-fg-dim hover:text-tokyo-pink transition duration-200">[ clear filter ]</a>
         {% endif %}
       </h1>
       <div class="flex flex-wrap gap-2 md:gap-3 lg:w-11/12 lg:mx-auto">

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -18,7 +18,7 @@
     <script type="text/javascript" src="{{ '/assets/main-bundle.js' }}"></script>
   </head>
   <body class="bg-beige-100 dark:bg-tokyo-bg font-mono text-stone-800 dark:text-tokyo-fg" data-controller="command-palette">
-    <div class="container mx-auto px-6 md:px-4">
+    <div class="container mx-auto px-4 sm:px-6 md:px-4">
       {% include header.html %}
       {{content}}
       {% include footer.html %}

--- a/src/_layouts/index.html
+++ b/src/_layouts/index.html
@@ -17,7 +17,7 @@ layout: default
       <div class="prose prose-custom prose-base md:prose-lg lg:prose-2xl dark:prose-invert typed-after">
         {{ content | markdownify }}
       </div>
-      <div class="mt-4 flex flex-wrap gap-3 font-mono text-sm md:text-base typed-after">
+      <div class="mt-4 flex flex-nowrap gap-2 sm:gap-3 font-mono text-xs xs:text-sm md:text-base typed-after whitespace-nowrap">
         <a href="#posts"
            class="px-3 py-1 border border-stone-400 dark:border-tokyo-border rounded-sm text-stone-700 dark:text-tokyo-fg hover:border-tokyo-blue hover:text-tokyo-blue dark:hover:border-tokyo-blue dark:hover:text-tokyo-blue transition duration-200">
           [ ~/posts ]

--- a/src/_layouts/index.html
+++ b/src/_layouts/index.html
@@ -5,19 +5,19 @@ layout: default
 <div class="flex flex-col pt-6 md:pt-12 lg:w-11/12 mx-auto">
   <div class="w-full flex flex-col-reverse md:flex-row justify-between mb-8 md:mb-16 lg:mb-24">
     <div class="self-start md:self-center md:w-1/3 mt-4 md:mt-0 flex flex-row md:flex-col justify-start md:justify-between">
-      <img class="self-center h-24 w-24 xs:h-28 xs:w-28 sm:h-32 sm:w-32 md:h-36 md:w-36 lg:h-40 lg:w-40 xl:h-48 xl:w-48 rounded-full object-cover border-double border-4 border-beige-500 dark:border-tokyo-border shadow-lg dark:shadow-tokyo-bg-alt" src="{{ page.image }}" alt="Rounded avatar">
+      <img class="self-center h-20 w-20 xs:h-28 xs:w-28 sm:h-32 sm:w-32 md:h-36 md:w-36 lg:h-40 lg:w-40 xl:h-48 xl:w-48 rounded-full object-cover border-double border-4 border-beige-500 dark:border-tokyo-border shadow-lg dark:shadow-tokyo-bg-alt" src="{{ page.image }}" alt="Rounded avatar">
       <div class="flex justify-center self-center md:mt-4 ml-4 md:ml-0">
         {% include social-networks.html %}
       </div>
     </div>
     <div class="md:w-3/4">
       <div class="font-mono text-sm md:text-base text-stone-600 dark:text-tokyo-fg-dim mb-2">
-        <span class="text-tokyo-green">eugenio@dev</span><span class="text-stone-500 dark:text-tokyo-fg-dim">:</span><span class="text-tokyo-blue">~</span><span class="text-stone-500 dark:text-tokyo-fg-dim">$</span> whoami
+        <span class="text-tokyo-green">eugenio@dev</span><span class="text-stone-500 dark:text-tokyo-fg-dim">:</span><span class="text-tokyo-blue">~</span><span class="text-stone-500 dark:text-tokyo-fg-dim">$</span> <span class="typed-cmd" style="--typed-ch: 6ch; --typed-steps: 6">whoami</span><span class="cursor-blink"></span>
       </div>
-      <div class="prose prose-custom prose-base md:prose-lg lg:prose-2xl dark:prose-invert">
+      <div class="prose prose-custom prose-base md:prose-lg lg:prose-2xl dark:prose-invert typed-after">
         {{ content | markdownify }}
       </div>
-      <div class="mt-4 flex flex-wrap gap-3 font-mono text-sm md:text-base">
+      <div class="mt-4 flex flex-wrap gap-3 font-mono text-sm md:text-base typed-after">
         <a href="#posts"
            class="px-3 py-1 border border-stone-400 dark:border-tokyo-border rounded-sm text-stone-700 dark:text-tokyo-fg hover:border-tokyo-blue hover:text-tokyo-blue dark:hover:border-tokyo-blue dark:hover:text-tokyo-blue transition duration-200">
           [ ~/posts ]

--- a/src/_layouts/index.html
+++ b/src/_layouts/index.html
@@ -27,6 +27,10 @@ layout: default
            class="px-3 py-1 border border-stone-400 dark:border-tokyo-border rounded-sm text-stone-700 dark:text-tokyo-fg hover:border-tokyo-green hover:text-tokyo-green dark:hover:border-tokyo-green dark:hover:text-tokyo-green transition duration-200">
           [ resume.pdf <span class="text-xs">↗</span> ]
         </a>
+        <a href="mailto:eugeniojimenes@gmail.com"
+           class="px-3 py-1 border border-stone-400 dark:border-tokyo-border rounded-sm text-stone-700 dark:text-tokyo-fg hover:border-tokyo-yellow hover:text-tokyo-yellow dark:hover:border-tokyo-yellow dark:hover:text-tokyo-yellow transition duration-200">
+          [ mailto ]
+        </a>
       </div>
     </div>
   </div>

--- a/src/assets/js/controllers/dark_mode_controller.js
+++ b/src/assets/js/controllers/dark_mode_controller.js
@@ -3,35 +3,29 @@ import { Controller } from "@hotwired/stimulus"
 // Dark-mode toggle. Pre-paint FOUC guard lives in
 // `_includes/head-darkmode-check.html` — it sets `<html class="dark">`
 // before stylesheet parse based on `localStorage.theme` + system preference.
-// This controller only owns the click-to-toggle behavior and the icon swap.
+// This controller owns click-to-toggle and the desktop icon swap.
 export default class extends Controller {
   static targets = ["darkIcon", "lightIcon"]
 
   connect() {
-    // Sync icon to whatever state the FOUC guard already applied.
-    // Show light-icon (i.e. "switch to light" affordance) when dark is active,
-    // and vice versa.
-    if (this.isDark()) {
-      this.lightIconTarget.classList.remove("hidden")
-    } else {
-      this.darkIconTarget.classList.remove("hidden")
+    if (this.hasLightIconTarget && this.hasDarkIconTarget) {
+      if (this.isDark()) {
+        this.lightIconTarget.classList.remove("hidden")
+      } else {
+        this.darkIconTarget.classList.remove("hidden")
+      }
     }
   }
 
   toggle() {
-    // Flip both icons. Whichever was hidden becomes visible.
-    this.lightIconTarget.classList.toggle("hidden")
-    this.darkIconTarget.classList.toggle("hidden")
-
-    // Single source of truth: the DOM class on <html>. Flip it, persist the
-    // new state to localStorage so the FOUC guard restores it on next load.
+    if (this.hasLightIconTarget && this.hasDarkIconTarget) {
+      this.lightIconTarget.classList.toggle("hidden")
+      this.darkIconTarget.classList.toggle("hidden")
+    }
     document.documentElement.classList.toggle("dark")
     localStorage.theme = document.documentElement.classList.contains("dark") ? "dark" : "light"
   }
 
-  // Resolves the current effective theme. Default is dark — only an explicit
-  // 'light' choice in localStorage opts out. Mirrors the FOUC guard logic so
-  // icons render in sync on first paint.
   isDark() {
     return localStorage.theme !== "light"
   }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -72,6 +72,122 @@
 
 @import "./css/syntax-highlight/highcontrast-monokai.css";
 
+/* ── Terminal tooltip (desktop hover/focus only) ────────────────── */
+[data-tip] { position: relative; }
+[data-tip]:hover::after,
+[data-tip]:focus-visible::after {
+  content: attr(data-tip);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 8px;
+  background: var(--color-tokyo-bg-alt);
+  color: var(--color-tokyo-fg);
+  border: 1px solid var(--color-tokyo-border);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1;
+  white-space: nowrap;
+  border-radius: 2px;
+  pointer-events: none;
+  z-index: 50;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  animation: tip-in 120ms ease-out;
+}
+@keyframes tip-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(-2px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+@media (hover: none) {
+  [data-tip]:hover::after { display: none; }
+}
+
+/* ── CRT scanlines (dark mode only) ─────────────────────────────── */
+:where(.dark) body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 100;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0 2px,
+    rgba(192, 202, 245, 0.04) 2px 3px
+  );
+  mix-blend-mode: overlay;
+}
+
+/* Faint grain (dark only) */
+:where(.dark) body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 99;
+  opacity: 0.05;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+
+/* ── Blinking terminal cursor ───────────────────────────────────── */
+@keyframes cursor-blink {
+  0%, 49%   { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+.cursor-blink::after {
+  content: "▊";
+  display: inline-block;
+  margin-left: 2px;
+  color: var(--color-tokyo-green);
+  animation: cursor-blink 1s step-end infinite;
+}
+
+/* ── Typed-in hero animation ────────────────────────────────────── */
+@keyframes typed-reveal {
+  from { max-width: 0; }
+  to   { max-width: var(--typed-ch, 10ch); }
+}
+.typed-cmd {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  vertical-align: bottom;
+  max-width: 0;
+  animation: typed-reveal 0.9s steps(var(--typed-steps, 6), end) 0.2s both;
+}
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.typed-after {
+  opacity: 0;
+  animation: fade-in 0.4s ease-out 1.2s forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .typed-cmd, .typed-after { animation: none; opacity: 1; width: auto; }
+  .cursor-blink::after { animation: none; }
+}
+
+/* ── Filelist row (terminal selection on hover) ─────────────────── */
+.filelist-row {
+  display: block;
+  padding: 0.75rem 0.5rem;
+  border-left: 2px solid transparent;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+@media (min-width: 640px) {
+  .filelist-row { padding: 0.75rem 1rem; }
+}
+.filelist-row:hover {
+  border-left-color: var(--color-tokyo-green);
+  background-color: rgba(122, 162, 247, 0.06);
+}
+:where(.dark) .filelist-row:hover {
+  background-color: rgba(122, 162, 247, 0.10);
+}
+.filelist-row .marker { color: var(--color-tokyo-fg-dim); }
+.filelist-row:hover .marker { color: var(--color-tokyo-green); }
+
 .align-left   { display: block; margin-left: auto; margin-right: auto; float: left;  margin-right: 1em; }
 .align-right  { display: block; margin-left: auto; margin-right: auto; float: right; margin-left: 1em; }
 .align-center { display: block; margin-left: auto; margin-right: auto; }


### PR DESCRIPTION
- filelist post rows replace shadow cards; date · read-min · slug.md
- CRT scanlines + grain overlay (dark only) via body::before/::after
- typed-in hero (`whoami`) + blinking cursor on prompt lines
- header: text buttons below md, icons + labels md+, ~/eugenio logo on <xs
- active-state styling on tags/about with aria-current
- CSS-only [data-tip] tooltip for translate icon + social links
- 44px hit targets on icon links, pagination numbers, clear-filter
- mobile tightening: container px-4, filelist padding, pagination wrap
- strip dead `align` include arg, drop icon-swap deps on mobile block